### PR TITLE
Use `note-occluded` class to style occluded notes

### DIFF
--- a/src/HubTextNote.js
+++ b/src/HubTextNote.js
@@ -10,11 +10,13 @@ const NOTE_TEXT_CLASS = 'note-text'; // style the text div, which may be content
 const NOTE_HOVER_CLASS = 'note-hover'; // style the hover state
 const NOTE_SELECT_CLASS = 'note-select'; // style the selected state
 const NOTE_DRAGGING_CLASS = 'note-dragging'; // style note while dragging
+const NOTE_OCCLUDED_CLASS = 'note-occluded'; // style occluded notes
 
 // CSS applied directly to each text note element
 // outer container, draggable
 const NOTE_CONTAINER_STYLE = `
   position: absolute; /* position notes relative to map container */
+  z-index: 1; /* relatve to the note container */
 `;
 
 // added to outer container when drag-drop is available
@@ -123,21 +125,23 @@ export default class HubTextNote {
     return this.container && this.container.classList.contains(NOTE_SELECT_CLASS);
   }
 
-  hidden () {
-    return this.container && parseFloat(this.container.style.opacity) === 0;
+  occluded () {
+    return this.container && this.container.classList.contains(NOTE_OCCLUDED_CLASS);
   }
 
   draggable () {
     return this.editable === true;
   }
 
-  setVisibility (state) {
+  setOccluded (state) {
     if (this.container) {
-      // TODO: consider allowing user-specified CSS class, might keep occluded notes visible but faded (e.g. opacity 50%)
-      this.container.style.opacity = state ? 1 : 0;
-      this.container.style.pointerEvents = state ? 'auto' : 'none';
-      this.textElement.style.opacity = state ? 1 : 0;
-      this.textElement.style.pointerEvents = state ? 'auto' : 'none';
+      if (state) {
+        this.container.classList.remove(NOTE_OCCLUDED_CLASS);
+        this.container.style.zIndex = 1;
+      } else {
+        this.container.classList.add(NOTE_OCCLUDED_CLASS);
+        this.container.style.zIndex = 0;
+      }
     }
   }
 
@@ -190,7 +194,7 @@ export default class HubTextNote {
     }
   }
 
-  createElements (view) {
+  createElements (view, notesContainer) {
     // setup outer note element, which is draggable (when editing is enable)
     this.container = document.createElement('div');
     this.container.style = `${NOTE_CONTAINER_STYLE} ${this.draggable() ? NOTE_DRAGGABLE_STYLE : ''}`;
@@ -266,7 +270,7 @@ export default class HubTextNote {
       this._handles.push(view.on('pointer-move', event => this.onDragEvent(event, view)));
     }
 
-    view.surface.appendChild(this.container); // add to view DOM
+    notesContainer.appendChild(this.container);
     this.updatePosition(view);
   }
 

--- a/src/HubTextNotesLayer.js
+++ b/src/HubTextNotesLayer.js
@@ -92,14 +92,14 @@ const HubTextNotesLayer = Layer.createSubclass({
     return this.hubNotes.filter(note => note.dragging).length > 0;
   },
 
-  // check notes for overlaps, and show/hide according to priority
+  // check notes for overlaps, and mark as occluded according to priority
   collideNotes () {
     const notesWithEls = this.hubNotes.filter(note => note.container);
-    const hidden = new Set();
+    const occluded = new Set();
     for (let a = 0; a < notesWithEls.length; a++) {
       const noteA = notesWithEls[a];
-      if (hidden.has(noteA)) {
-        continue; // skip to-be-hidden elements
+      if (occluded.has(noteA)) {
+        continue; // skip to-be-occluded elements
       }
 
       for (let b = a + 1; b < notesWithEls.length; b++) {
@@ -109,31 +109,30 @@ const HubTextNotesLayer = Layer.createSubclass({
         if (elementsIntersect(noteA.container, noteB.container)) {
           // keep notes in priority of: dragging, focused, selected, hovered, most recently added
           if (noteA.dragging) {
-            hidden.add(noteB);
+            occluded.add(noteB);
           } else if (noteB.dragging) {
-            hidden.add(noteA);
+            occluded.add(noteA);
           } else if (noteA.focused()) {
-            hidden.add(noteB);
+            occluded.add(noteB);
           } else if (noteB.focused()) {
-            hidden.add(noteA);
+            occluded.add(noteA);
           } else if (noteA.selected()) {
-            hidden.add(noteB);
+            occluded.add(noteB);
           } else if (noteB.selected()) {
-            hidden.add(noteA);
+            occluded.add(noteA);
           // NOTE: disable hover priority for now and revisit, can be too distracting/frustrating with many notes
-          // } else if (noteA.hovered()) {
-          //   hidden.add(noteB);
-          // } else if (noteB.hovered()) {
-          //   hidden.add(noteA);
+          } else if (noteA.hovered()) {
+            occluded.add(noteB);
+          } else if (noteB.hovered()) {
+            occluded.add(noteA);
           } else {
-            hidden.add(a >= b ? noteB : noteA);
+            occluded.add(a >= b ? noteB : noteA);
           }
         }
       }
     }
 
-    // hide/show each note
-    this.hubNotes.forEach(note => note.setVisibility(!hidden.has(note)));
+    this.hubNotes.forEach(note => note.setOccluded(!occluded.has(note)));
   },
 
   // convert all notes to TextSymbol graphics

--- a/test/HubTextNoteTest.js
+++ b/test/HubTextNoteTest.js
@@ -23,8 +23,10 @@ describe('HubNote', () => {
 
   beforeEach(() => {
     view = createView();
+    const notesContainer = document.createElement('div'); // created by layer view
+
     note = new HubTextNote({ graphic: polygonGraphic, text: 'this is a test note', cssClass: 'map-note' });
-    note.createElements(view);
+    note.createElements(view, notesContainer);
     document.body.appendChild(note.container); // needs to be in DOM for some tests like focus
   });
 
@@ -61,10 +63,10 @@ describe('HubNote', () => {
     assert.equal(note.focused(), true);
   });
 
-  it('hides the note', () => {
-    assert.equal(note.hidden(), false);
-    note.setVisibility(false);
-    assert.equal(note.hidden(), true);
+  it('occludes the note', () => {
+    assert.equal(note.occluded(), false);
+    note.setOccluded(false);
+    assert.equal(note.occluded(), true);
   });
 
   it('converts the note to a graphic', () => {


### PR DESCRIPTION
Previously, any notes that were occluded during the collision detection phase were simply hidden by forcing `opacity: 0`. To provide a more flexible solution, this PR switches to applying a `note-occluded` CSS class that the client can use to style these notes. The layer will still force any "foreground" notes to be on top by setting `z-index: 1` (relative to a parent container holding all notes). This means that without any additional styling applied, the default behavior will now keep all notes visible, but with the occluded ones in the background (setting `z-index` directly was to preserve good default behavior, but maybe there is another approach?). Additional effects such as changing color, opacity, border size, etc. could then be applied with `note-occluded`.

The PR re-structures the notes DOM so that all notes are now attached to a `notesContainer` managed by the layer view. Other than that and the logic to apply the CSS class, a good portion of code is terminology changes from "hidden" to more generic "occluded".
