### PR TITLE
Support Feature Layers

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,9 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@babel/core": "^7.10.3",
-    "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/preset-env": "^7.10.3",
-    "@rollup/plugin-babel": "^5.0.4",
-    "@rollup/plugin-commonjs": "^13.0.0",
-    "@rollup/plugin-node-resolve": "^8.1.0",
+    "@babel/plugin-proposal-class-properties": "^7.8.3",
+    "babel-plugin-transform-async-to-promises": "^0.8.15",
     "chai": "^4.2.0",
     "core-js": "^3.6.5",
     "esri-loader": "^2.14.0",
@@ -29,6 +27,9 @@
     "karma-rollup-preprocessor": "^7.0.5",
     "mocha": "^7.1.2",
     "rollup": "^2.18.0",
+    "@rollup/plugin-babel": "^5.0.4",
+    "@rollup/plugin-commonjs": "^13.0.0",
+    "@rollup/plugin-node-resolve": "^8.1.0",
     "rollup-plugin-terser": "^5.3.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ export default {
           }
         ]
       ],
-      plugins: ['@babel/plugin-proposal-class-properties'],
+      plugins: ['@babel/plugin-proposal-class-properties', 'transform-async-to-promises'],
       exclude: 'node_modules/**'
     })
   ]

--- a/src/HubTextNote.js
+++ b/src/HubTextNote.js
@@ -55,6 +55,8 @@ export default class HubTextNote {
   static Point = Point;
   static geometryEngine = geometryEngine;
   static screenUtils = screenUtils;
+  static symbolUtils = symbolUtils;
+  static webMercatorUtils = webMercatorUtils;
 
   static octantOffsets = [
     [1, 0], // right
@@ -457,7 +459,7 @@ export default class HubTextNote {
     const noteSize = [this.container.offsetWidth, this.container.offsetHeight];
 
     // JSAPI may need to compute symbol, e.g. for feature layers
-    const symbol = await symbolUtils.getDisplayedSymbol(this.graphic, view);
+    const symbol = await HubTextNote.symbolUtils.getDisplayedSymbol(this.graphic, view);
     const graphicSize = (symbol.type === 'picture-marker' ?
       [symbol.width, symbol.height] : // width/height from picture marker
       [symbol.size + symbol.outline.width, symbol.size + symbol.outline.width]) // size from simple marker
@@ -600,7 +602,7 @@ export default class HubTextNote {
 
     // center-point of attached graphic, can be anywhere stable on the target graphic,
     // just needs to provide an offset from a point on the graphic to the anchor
-    const center = webMercatorUtils.project(
+    const center = HubTextNote.webMercatorUtils.project(
       this.graphic.geometry.type === 'point' ?
         this.graphic.geometry : this.graphic.geometry.extent.center,
       this.anchor.spatialReference
@@ -620,7 +622,7 @@ export default class HubTextNote {
       return;
     }
 
-    const center = webMercatorUtils.project(
+    const center = HubTextNote.webMercatorUtils.project(
       this.graphic.geometry.type === 'point' ?
         this.graphic.geometry : this.graphic.geometry.extent.center,
       this.anchor.spatialReference

--- a/src/HubTextNote.js
+++ b/src/HubTextNote.js
@@ -80,10 +80,11 @@ export default class HubTextNote {
   constructor ({
       id, editable = false, graphic, placement = {},
       text = '', textPlaceholder = '', textMaxCharacters, cssClass,
-      onNoteEvent,
+      onNoteEvent, onNoteFirstPlacement
     }) {
     Object.assign(this, { id, editable, graphic, text, textPlaceholder, textMaxCharacters, cssClass, placement });
     this.emitNoteEvent = typeof onNoteEvent === 'function' ? onNoteEvent : function(){}; // provide an empty callback as fallback
+    this.onNoteFirstPlacement = typeof onNoteFirstPlacement === 'function' ? onNoteFirstPlacement : function(){};
     this.anchor = null; // a point on the graphic that the text note is positioned relative to
     this.mapPoint = null; // the current computed map point for the text note element
     this.dragging = false; // is note actively being dragged
@@ -384,10 +385,14 @@ export default class HubTextNote {
 
   // Update text note position in world space and screenspace
   async updatePosition (view) {
+    const firstPlacement = (this.mapPoint == null);
     const changed = await this.updateMapPoint(view);
     this.updateTextElement(view);
     if (changed) {
       this.emitNoteEvent('update-position', this, { type: 'update-position' });
+      if (firstPlacement) {
+        this.onNoteFirstPlacement();
+      }
     }
   }
 

--- a/src/HubTextNote.js
+++ b/src/HubTextNote.js
@@ -138,7 +138,8 @@ export default class HubTextNote {
   }
 
   draggable () {
-    return this.editable === true;
+    return this.editable === true &&
+      (this.graphic.geometry.type !== 'point' || this.placement.pointAlignments.length > 1);
   }
 
   setOccluded (state) {

--- a/src/HubTextNotesLayer.js
+++ b/src/HubTextNotesLayer.js
@@ -30,7 +30,14 @@ const HubTextNotesLayer = Layer.createSubclass({
     this.emit(`note-${type}`, { note, ...event });
   },
 
-  addNoteForGraphic (graphic, { text, placement } = {}) {
+  async addNoteForGraphic (graphic, { text, placement } = {}) {
+    // promise that resolves when note is placed for the first time
+    let onNoteFirstPlacement;
+    const notePlaced = new Promise(resolve => {
+      onNoteFirstPlacement = () => resolve();
+    });
+
+    // create note
     const note = new HubTextNote({
       id: this.noteId++,
       editable: this.editable,
@@ -40,10 +47,14 @@ const HubTextNotesLayer = Layer.createSubclass({
       textMaxCharacters: this.textMaxCharacters,
       cssClass: this.cssClass,
       placement,
-      onNoteEvent: this.onNoteEvent.bind(this)
+      onNoteEvent: this.onNoteEvent.bind(this),
+      onNoteFirstPlacement
     });
     this.hubNotes.push(note);
     this.emit('note-add', { note });
+
+    // wait for initial placement, so caller can access note location on map
+    await notePlaced;
     return note;
   },
 

--- a/src/HubTextNotesLayer.js
+++ b/src/HubTextNotesLayer.js
@@ -73,10 +73,10 @@ const HubTextNotesLayer = Layer.createSubclass({
       return note;
     }
 
-    // then fallback to comparing by object id, necessary for features from a FeatureLayer.hitTest()
+    // then fallback to comparing by layer and object id, necessary for features from a FeatureLayer.hitTest()
     return this.hubNotes
-      .filter(note => note.graphic.getObjectId() != null)
-      .find(note => note.graphic.getObjectId() === graphic.getObjectId());
+      .filter(note => note.graphic.layer.id != null && note.graphic.getObjectId() != null)
+      .find(note => note.graphic.layer.id === graphic.layer.id && note.graphic.getObjectId() === graphic.getObjectId());
   },
 
   setHoveredNoteForGraphic (graphic) {

--- a/src/HubTextNotesLayer.js
+++ b/src/HubTextNotesLayer.js
@@ -82,8 +82,8 @@ const HubTextNotesLayer = Layer.createSubclass({
     });
   },
 
-  updateNotePositions (view) {
-    this.hubNotes.forEach(note => note.updatePosition(view));
+  async updateNotePositions (view) {
+    await Promise.all(this.hubNotes.map(note => note.updatePosition(view)));
   },
 
   dragging () {

--- a/src/HubTextNotesLayer.js
+++ b/src/HubTextNotesLayer.js
@@ -30,13 +30,7 @@ const HubTextNotesLayer = Layer.createSubclass({
     this.emit(`note-${type}`, { note, ...event });
   },
 
-  async addNoteForGraphic (graphic, { text, placement } = {}) {
-    // promise that resolves when note is placed for the first time
-    let onNoteFirstPlacement;
-    const notePlaced = new Promise(resolve => {
-      onNoteFirstPlacement = () => resolve();
-    });
-
+  addNoteForGraphic (graphic, { text, placement } = {}) {
     // create note
     const note = new HubTextNote({
       id: this.noteId++,
@@ -47,14 +41,11 @@ const HubTextNotesLayer = Layer.createSubclass({
       textMaxCharacters: this.textMaxCharacters,
       cssClass: this.cssClass,
       placement,
-      onNoteEvent: this.onNoteEvent.bind(this),
-      onNoteFirstPlacement
+      onNoteEvent: this.onNoteEvent.bind(this)
     });
     this.hubNotes.push(note);
-    this.emit('note-add', { note });
 
-    // wait for initial placement, so caller can access note location on map
-    await notePlaced;
+    this.emit('note-add', { note });
     return note;
   },
 

--- a/src/HubTextNotesLayer.js
+++ b/src/HubTextNotesLayer.js
@@ -65,7 +65,16 @@ const HubTextNotesLayer = Layer.createSubclass({
 
   // retrieve note by referenced graphic
   findNoteForGraphic (graphic) {
-    return this.hubNotes.find(note => note.graphic === graphic);
+    // first look for a note with same graphic identity, should work for GraphicsLayer
+    let note = this.hubNotes.find(note => note.graphic === graphic);
+    if (note) {
+      return note;
+    }
+
+    // then fallback to comparing by object id, necessary for features from a FeatureLayer.hitTest()
+    return this.hubNotes
+      .filter(note => note.graphic.getObjectId() != null)
+      .find(note => note.graphic.getObjectId() === graphic.getObjectId());
   },
 
   setHoveredNoteForGraphic (graphic) {

--- a/src/HubTextNotesLayer.js
+++ b/src/HubTextNotesLayer.js
@@ -30,7 +30,7 @@ const HubTextNotesLayer = Layer.createSubclass({
     this.emit(`note-${type}`, { note, ...event });
   },
 
-  addNoteForGraphic (graphic, { text, placementHint, placementAlignments } = {}) {
+  addNoteForGraphic (graphic, { text, placement } = {}) {
     const note = new HubTextNote({
       id: this.noteId++,
       editable: this.editable,
@@ -39,8 +39,7 @@ const HubTextNotesLayer = Layer.createSubclass({
       textPlaceholder: this.textPlaceholder,
       textMaxCharacters: this.textMaxCharacters,
       cssClass: this.cssClass,
-      placementHint,
-      placementAlignments,
+      placement,
       onNoteEvent: this.onNoteEvent.bind(this)
     });
     this.hubNotes.push(note);

--- a/src/HubTextNotesLayerView2D.js
+++ b/src/HubTextNotesLayerView2D.js
@@ -31,7 +31,7 @@ const HubTextNotesLayerView2D = GraphicsLayerView2D.createSubclass({
 
     // add event handlers
     this._handles.push(this.layer.on('note-add', event => this.addNoteElements(event.note)));
-    this._handles.push(this.layer.on(['note-select', 'note-hover', 'note-drag'], () => this.setDirty(true)));
+    this._handles.push(this.layer.on(['note-select', 'note-hover', 'note-drag', 'note-blur'], () => this.setDirty(true)));
     this._handles.push(this.view.watch('extent', () => this.setDirty(true)));
   },
 

--- a/src/HubTextNotesLayerView2D.js
+++ b/src/HubTextNotesLayerView2D.js
@@ -66,10 +66,12 @@ const HubTextNotesLayerView2D = GraphicsLayerView2D.createSubclass({
     // render calls much more frequently than we need to update, so only run collision and DOM updates when needed
     if (this._dirty) {
       this.setDirty(false);
-      this.layer.updateNotePositions(this.view); // update text note positions in world/screen
-      if (this.view.stationary) {
-        this.layer.collideNotes(); // update text note visibility based on collisions
-      }
+      // update text note positions in world/screen
+      this.layer.updateNotePositions(this.view).then(() => {
+        if (this.view.stationary) {
+          this.layer.collideNotes(); // update text note visibility based on collisions
+        }
+      });
     }
   },
 

--- a/src/HubTextNotesLayerView2D.js
+++ b/src/HubTextNotesLayerView2D.js
@@ -86,7 +86,9 @@ const HubTextNotesLayerView2D = GraphicsLayerView2D.createSubclass({
       geometry: notes[0].mapPoint, // TODO: add full note extent if deemed necessary
       attributes: {
         id: notes[0].id,
-        text: notes[0].text
+        text: notes[0].text,
+        graphicObjectId: notes[0].graphic.getObjectId(),
+        graphicLayerId: notes[0].graphic.layer.id
       },
       layer: this.layer,
       sourceLayer: this.layer

--- a/test/HubTextNoteTest.js
+++ b/test/HubTextNoteTest.js
@@ -10,31 +10,36 @@ const assert = chai.assert;
 
 describe('HubNote', () => {
 
-  let note, view;
+  let note, view, notesContainer;
 
   before(async () => {
     // load JSAPI dependencies
-    const [Point, geometryEngine, screenUtils] = await loadModules([
-      'esri/geometry/Point', 'esri/geometry/geometryEngine', 'esri/core/screenUtils'
+    const [Point, geometryEngine, screenUtils, symbolUtils, webMercatorUtils] = await loadModules([
+      'esri/geometry/Point',
+      'esri/geometry/geometryEngine',
+      'esri/core/screenUtils',
+      'esri/symbols/support/symbolUtils',
+      'esri/geometry/support/webMercatorUtils'
     ]);
-    Object.assign(HubTextNote, { Point, geometryEngine, screenUtils });
+    Object.assign(HubTextNote, { Point, geometryEngine, screenUtils, symbolUtils, webMercatorUtils });
     return Promise.resolve(); // avoids some timeout errors (?)
   });
 
   beforeEach(() => {
     view = createView();
-    const notesContainer = document.createElement('div'); // created by layer view
+    notesContainer = document.createElement('div'); // created by layer view
+    document.body.appendChild(notesContainer);
 
     note = new HubTextNote({ graphic: polygonGraphic, text: 'this is a test note', cssClass: 'map-note' });
     note.createElements(view, notesContainer);
-    document.body.appendChild(note.container); // needs to be in DOM for some tests like focus
+    notesContainer.appendChild(note.container); // needs to be in DOM for some tests like focus
   });
 
   afterEach(() => {
-    document.body.removeChild(note.container);
+    document.body.removeChild(notesContainer);
   });
 
-  it('returns an new note instance', () => {
+  it('returns a new note instance', () => {
     assert.instanceOf(note, HubTextNote);
   });
 

--- a/test/fixtures/noteGraphic.js
+++ b/test/fixtures/noteGraphic.js
@@ -31,7 +31,7 @@ export default {
     ],
     "horizontalAlignment": "center",
     "verticalAlignment": "middle",
-    "xoffset": 0.07448797393590212,
+    "xoffset": 0.4694879734888673,
     "yoffset": -0.008748816791921854
   },
   "attributes": {

--- a/test/fixtures/polygonGraphic.js
+++ b/test/fixtures/polygonGraphic.js
@@ -63,7 +63,7 @@ export default {
           "x": -8563600.549432032,
           "y": 4707872.199839918,
         };
-      } 
+      }
     },
     // Shimmed data (result of extent getter on polygon)
     "extent": {
@@ -74,8 +74,16 @@ export default {
       "xmin": -8565347.170438128,
       "ymin": 4705409.454599368,
       "xmax": -8561538.564874137,
-      "ymax": 4710213.193386729
-    }    
+      "ymax": 4710213.193386729,
+      "center": {
+        "spatialReference": {
+          "latestWkid": 3857,
+          "wkid": 102100
+        },
+        "x": -8563600.549432032,
+        "y": 4707872.199839918,
+      }
+    },
   },
   "symbol": {
     "type": "esriSFS",
@@ -98,5 +106,8 @@ export default {
     },
     "style": "esriSFSSolid"
   },
-  "attributes": {}
+  "attributes": {},
+
+  // Shimmed function
+  watch() {}
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,6 +1022,11 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-transform-async-to-promises@^0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.15.tgz#13b6d8ef13676b4e3c576d3600b85344bb1ba346"
+  integrity sha512-fDXP68ZqcinZO2WCiimCL9zhGjGXOnn3D33zvbh+yheZ/qOrNVVDDIBtAaM3Faz8TRvQzHiRKsu3hfrBAhEncQ==
+
 backo2@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"


### PR DESCRIPTION
This PR makes necessary changes for text notes to be attached to features in a Feature Layer, along with a couple other interface changes:

- Using `symbolUtils.getDisplayedSymbol()` to get the symbol dynamically for points. For plain Graphics Layer, this isn't necessary since the symbol is always statically available on the graphic. Feature Layers may need to resolve this through the renderer.
- Because resolving the symbol size for a feature is now async, the note is not guaranteed to be placed when `HubTextNotesLayer.addNoteForGraphic()` returns. For cases where you want to take some follow-up action that relies on position (e.g. Hub checking to see if the note is in the current view extent), `HubTextNote.placed()` will return a promise that resolves upon placement.
- When searching for notes by graphic, object identity is sufficient for Graphics Layers, but not for Feature Layer. When object identity fails, we now fall back to check for the same object id with `graphic.getObjectId()`
- Consolidation of placement-related options into a single `placement` object:
  - `placementHint` => `placement.hint`
  - `placementAlignments` => `placement.pointAlignments` (clarify usage)
- Addition of `placement.outsidePolygon` option to allow polygon notes to be allowed to move outside the polygon interior (default), or to be constrained to the interior. This was added as a result of testing Feature Layers with shared polygon boundaries, such as political districts, where it can be misleading to allow the note to be placed in an adjacent polygon.

