### PR TITLE
HubTextNotesLayerView2D conditionally creates GraphicsView2D in attac…

### DIFF
--- a/src/HubTextNotesLayerView2D.js
+++ b/src/HubTextNotesLayerView2D.js
@@ -1,4 +1,6 @@
 import * as GraphicsLayerView2D from 'esri/views/2d/layers/GraphicsLayerView2D';
+import GraphicsView2D from 'esri/views/2d/layers/graphics/GraphicsView2D';
+import GraphicContainer from 'esri/views/2d/layers/graphics/GraphicContainer';
 import * as Graphic from 'esri/Graphic';
 
 const NOTES_CONTAINER_STYLE = `
@@ -20,6 +22,19 @@ const HubTextNotesLayerView2D = GraphicsLayerView2D.createSubclass({
   },
 
   attach () {
+    // prior to 4.23, graphicsView was created in GraphicsLayerView2D initialize lifecycle method.
+    // since 4.23, the initialize lifecycle has been deprecated and graphicsView is now created
+    // in attach method, which is being overridden here. so we must create the graphicsView here
+    // when one does not already exist.
+    if (!this.graphicsView) {
+      this.graphicsView = new GraphicsView2D({
+        requestUpdateCallback: () => this.requestUpdate(),
+        view: this.view,
+        graphics: this.layer.graphics,
+        container: new GraphicContainer(this.view.featuresTilingScheme)
+      });
+    }
+
     // create container for notes and attach to map view DOM
     this.notesContainer = document.createElement('div');
     this.notesContainer.classList.add('hub-text-notes');


### PR DESCRIPTION
…h to support 4.23 and preserve backwards compatibility

Prior to v4.23, [GraphicsLayerView2D](https://devtopia.esri.com/WebGIS/arcgis-js-api/blob/ad43611b413b1d0a625293a3ce87543dde5c1fa2/esri/views/2d/layers/GraphicsLayerView2D.ts#L45) created a `GraphicsView2D` instance from the `initialize` lifecycle method.

Since to v4.23, the `initialize` lifecycle method has been deprecated and [GraphicsLayerView2D](https://devtopia.esri.com/WebGIS/arcgis-js-api/blob/ecb69ff5e08a61c162de0ddc0b1f397ed5d4071b/esri/views/2d/layers/GraphicsLayerView2D.ts#L72) now creates the `GraphicsView2D` instance from the `attach` method, but `HubTextNotesLayerView2D` overrides the `attach` method.

This PR updates `HubTextNotesLayerView2D` to conditionally create the `GraphicsView2D` from the `attach` method when one does not already exist to support v4.23 while preserving backwards compatibility.